### PR TITLE
Copy assets files with the migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ git clone https://github.com/okkez/redmine_full_text_search.git full_text_sear
 
 ```text
 $ cd redmine
-$ ./bin/rake redmine:plugins:migrate RAILS_ENV=production
+$ ./bin/rake redmine:plugins RAILS_ENV=production
 ```
 
 And restart Redmine.


### PR DESCRIPTION
I think `bin/rake redmine:plugins` is better than `bin/rake redmine:plugins:migrate` to install plugins
coz `bin/rake redmine:plugins` = `bin/rake redmine:plugins:migrate` + `bin/rake redmine:plugins:assets`.